### PR TITLE
Allow blacklisting of wireless interfaces

### DIFF
--- a/DroneBridgeConfig.ini
+++ b/DroneBridgeConfig.ini
@@ -32,6 +32,9 @@ video_blocklength=1024
 # Video FPS - Choose between 30, 40, 48, 59.9
 fps=48
 
+# Uncomment to blacklist a network interface from being changed. Useful if using RPi ZeroW in headless mode and need internal wifi to remain unchanged
+# Set to  'wlan0' for RPi Zero or MAC address of adapter to ignore
+; blacklist_ap='wlan0'
 
 [GROUND]
 # ---------------------------------------------------------------

--- a/startup/common_helpers.py
+++ b/startup/common_helpers.py
@@ -6,7 +6,6 @@ PATH_CONFIG_FILE = os.path.join(os.sep, "boot", "DroneBridgeConfig.ini")
 PI3_WIFI_NIC = 'intwifi0'
 HOTSPOT_NIC = 'wifihotspot0'
 
-
 def read_dronebridge_config():
     """
     Reads the DroneBridge config file


### PR DESCRIPTION
I added code to allow a specific wireless interface to be blacklisted. This is useful when running the RPi ZeroW in headless mode and setting up DroneBridge - otherwise, the internal card is set to monitor mode and you lose connection to the Pi.

I also refactored the code to make use of the same mechanism for the Wifi Hotspot, and to ensure that GROUND config is not used when setting up the AIR side as this can get confusing.